### PR TITLE
Add a coffeelint config file saying "ignore line lengths"

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,0 +1,5 @@
+{
+    "max_line_length": {
+        "level": "ignore"
+    }
+}


### PR DESCRIPTION
This makes it possible to edit this project with Atom's linter-coffeelint
package installed without getting warnings about long lines.