### PR TITLE
Run tests once on startup

### DIFF
--- a/lib/test-status-status-bar-view.coffee
+++ b/lib/test-status-status-bar-view.coffee
@@ -23,13 +23,13 @@ class TestStatusStatusBarView extends View
     @statusBarSub = atom.workspace.observeTextEditors (editor) =>
       @subscriptions.add editor.onDidSave ->
         return unless atom.config.get('test-status.autorun')
-        execute_tests()
+        executeCommand()
 
     atom.commands.add 'atom-workspace',
-      'test-status:run-tests': -> execute_tests()
+      'test-status:run-tests': -> executeCommand()
 
   # Run the tests
-  execute_tests: ->
+  executeCommand: ->
     @commandRunner.run(@testStatus)
 
   # Internal: Attach the status bar view to the status bar.

--- a/lib/test-status-status-bar-view.coffee
+++ b/lib/test-status-status-bar-view.coffee
@@ -21,12 +21,12 @@ class TestStatusStatusBarView extends View
 
     @subscriptions = new CompositeDisposable
     @statusBarSub = atom.workspace.observeTextEditors (editor) =>
-      @subscriptions.add editor.onDidSave ->
+      @subscriptions.add editor.onDidSave =>
         return unless atom.config.get('test-status.autorun')
-        executeCommand()
+        @executeCommand()
 
     atom.commands.add 'atom-workspace',
-      'test-status:run-tests': -> executeCommand()
+      'test-status:run-tests': => @executeCommand()
 
   # Run the tests
   executeCommand: ->

--- a/lib/test-status-status-bar-view.coffee
+++ b/lib/test-status-status-bar-view.coffee
@@ -21,12 +21,16 @@ class TestStatusStatusBarView extends View
 
     @subscriptions = new CompositeDisposable
     @statusBarSub = atom.workspace.observeTextEditors (editor) =>
-      @subscriptions.add editor.onDidSave =>
+      @subscriptions.add editor.onDidSave ->
         return unless atom.config.get('test-status.autorun')
-        @commandRunner.run(@testStatus)
+        execute_tests()
 
     atom.commands.add 'atom-workspace',
-      'test-status:run-tests': => @commandRunner.run(@testStatus)
+      'test-status:run-tests': -> execute_tests()
+
+  # Run the tests
+  execute_tests: ->
+    @commandRunner.run(@testStatus)
 
   # Internal: Attach the status bar view to the status bar.
   #

--- a/lib/test-status.coffee
+++ b/lib/test-status.coffee
@@ -13,6 +13,10 @@ module.exports =
     createStatusEntry = =>
       @testStatusStatusBar = new TestStatusStatusBarView
 
+      # Run tests once on startup
+      if atom.config.get('test-status.autorun')
+        @testStatusStatusBar.execute_tests()
+
     statusBar = document.querySelector('status-bar')
 
     if statusBar?

--- a/lib/test-status.coffee
+++ b/lib/test-status.coffee
@@ -15,7 +15,7 @@ module.exports =
 
       # Run tests once on startup
       if atom.config.get('test-status.autorun')
-        @testStatusStatusBar.execute_tests()
+        @testStatusStatusBar.executeCommand()
 
     statusBar = document.querySelector('status-bar')
 


### PR DESCRIPTION
Before this change, you had to explicitly save a file before the tests were
run the first time.

With this change in place, we run the tests once at startup so that the test
status icon has the correct color from the get go.