### PR TITLE
Kill tests after timeout

### DIFF
--- a/lib/command-runner.coffee
+++ b/lib/command-runner.coffee
@@ -66,6 +66,8 @@ class CommandRunner
         output += data.toString()
 
       proc.on 'exit', (code, signal) =>
+        clearTimeout(@timeout) if @timeout?
+
         output += "\nTerminated by " + signal + "\n" if signal?
 
         @running = false

--- a/lib/command-runner.coffee
+++ b/lib/command-runner.coffee
@@ -79,10 +79,12 @@ class CommandRunner
           testStatus.removeClass('pending success').addClass('fail')
 
       clearTimeout(@timeout) if @timeout?
+      timeoutInSeconds = atom.config.get('test-status.timeoutInSeconds')
+      timeoutInMs = timeoutInSeconds * 1000
       @timeout = setTimeout ->
-        output += "\n\nERROR: Timed out after 1s\n"
+        output += "\n\nERROR: Timed out after " + timeoutInSeconds + "s\n"
         proc.kill()
-      , 1000
+      , timeoutInMs
     catch err
       @running = false
       testStatus.removeClass('pending success').addClass('fail')

--- a/lib/test-status.coffee
+++ b/lib/test-status.coffee
@@ -6,6 +6,12 @@ module.exports =
       type: 'boolean'
       default: true
 
+    timeoutInSeconds:
+      type: 'integer'
+      default: 5
+      minimum: 1
+      description: 'Test jobs will be terminated if they run longer than this'
+
   # Public: Active the package and initialize the test-status views.
   #
   # Returns nothing.

--- a/lib/test-status.coffee
+++ b/lib/test-status.coffee
@@ -8,7 +8,7 @@ module.exports =
 
     timeoutInSeconds:
       type: 'integer'
-      default: 5
+      default: 60
       minimum: 1
       description: 'Test jobs will be terminated if they run longer than this'
 


### PR DESCRIPTION
If a test runs too long, kill it.

The timeout is configurable in the settings.

I arbitrarily set the default timeout to 60s.

Also, if a test is terminated with a signal, print the signal name at the end of the test output.